### PR TITLE
fix(package): make io-ts and fp-ts peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1970,6 +1970,7 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
       "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "dev": true,
       "requires": {
         "follow-redirects": "1.5.10"
       }
@@ -4028,6 +4029,7 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
       "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
       "requires": {
         "debug": "=3.1.0"
       },
@@ -4036,6 +4038,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -4066,9 +4069,10 @@
       }
     },
     "fp-ts": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.6.2.tgz",
-      "integrity": "sha512-RUm0iNcD7eMFZo6W1K10kqi0DyYX06lbbjyNgKwEWg1kPZw91ZXlkEx/9cII1x/jY4fHzh14+Hquk5sJnXBzQA=="
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.6.5.tgz",
+      "integrity": "sha512-lQNzOMJj98b623+UZLQ+tnN/8qtNXz/vRoR9k7L/9OlUIyYH3qVzSUVZBDXYsAd7nOWzzdQALCX1ZqcF70altQ==",
+      "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -4615,7 +4619,8 @@
     "io-ts": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.4.tgz",
-      "integrity": "sha512-a8A/3jekTgSPfQ+OG40sTiX2gohXZz89X1+TfKsWJ/vpA2dBilBkrGYPiDE8OaKMMG7xm5ma3SAZL5eNr4Bi2w=="
+      "integrity": "sha512-a8A/3jekTgSPfQ+OG40sTiX2gohXZz89X1+TfKsWJ/vpA2dBilBkrGYPiDE8OaKMMG7xm5ma3SAZL5eNr4Bi2w==",
+      "dev": true
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -8245,7 +8250,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Gets upset if your API data is bad!",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "types": "dist/index.d.ts",
   "repository": "https://github.com/williamareynolds/grumpus.git",
   "author": "William Reynolds <williamareynolds@icloud.com>",
@@ -70,11 +72,14 @@
     "@types/node": "^14.0.11",
     "@typescript-eslint/eslint-plugin": "^3.1.0",
     "@typescript-eslint/parser": "^3.1.0",
+    "axios": "^0.19.2",
     "commitizen": "^4.1.2",
     "cz-conventional-changelog": "^3.2.0",
     "eslint": "^7.2.0",
     "fast-check": "^1.24.2",
+    "fp-ts": "^2.6.5",
     "husky": "^4.2.5",
+    "io-ts": "^2.2.4",
     "jest": "^26.0.1",
     "lint-staged": "^10.2.9",
     "npm-run-all": "^4.1.5",
@@ -85,9 +90,11 @@
     "typescript": "^3.9.5"
   },
   "dependencies": {
-    "axios": "^0.19.2",
-    "fp-ts": "^2.6.2",
-    "io-ts": "^2.2.4",
     "jest-mock-axios": "^4.2.0"
+  },
+  "peerDependencies": {
+    "axios": ">=0.17.0 <0.20.0",
+    "fp-ts": "^2",
+    "io-ts": "^2.2.4"
   }
 }


### PR DESCRIPTION
These packages need to be used directly by consumers of this package. That makes them perfect for
peer dependencies. This should prevent unexpected conflicts.

fix #4