### PR TITLE
Prevent exceptions from axios calls

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,12 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
   ],
   rules: {
-    '@typescript-eslint/no-unused-vars': 'error'
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        args: 'all',
+        argsIgnorePattern: '^_'
+      }
+    ]
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1970,7 +1970,6 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
       "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "dev": true,
       "requires": {
         "follow-redirects": "1.5.10"
       }
@@ -4029,7 +4028,6 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
       "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "dev": true,
       "requires": {
         "debug": "=3.1.0"
       },
@@ -4038,7 +4036,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -6373,6 +6370,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/jest-mock-axios/-/jest-mock-axios-4.2.0.tgz",
       "integrity": "sha512-tGvXQLfC0xmRo+EUpmAapsbWXh/83y82sPsZbePj2SsCIMvAsN0okARTOjbuYYffddF7YoQwaJ8++wGsslh3Xw==",
+      "dev": true,
       "requires": {
         "synchronous-promise": "^2.0.10"
       }
@@ -8250,8 +8248,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -9887,7 +9884,8 @@
     "synchronous-promise": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.13.tgz",
-      "integrity": "sha512-R9N6uDkVsghHePKh1TEqbnLddO2IY25OcsksyFp/qBe7XYd0PVbKEWxhcdMhpLzE1I6skj5l4aEZ3CRxcbArlA=="
+      "integrity": "sha512-R9N6uDkVsghHePKh1TEqbnLddO2IY25OcsksyFp/qBe7XYd0PVbKEWxhcdMhpLzE1I6skj5l4aEZ3CRxcbArlA==",
+      "dev": true
     },
     "table": {
       "version": "5.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6366,15 +6366,6 @@
         }
       }
     },
-    "jest-mock-axios": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/jest-mock-axios/-/jest-mock-axios-4.2.0.tgz",
-      "integrity": "sha512-tGvXQLfC0xmRo+EUpmAapsbWXh/83y82sPsZbePj2SsCIMvAsN0okARTOjbuYYffddF7YoQwaJ8++wGsslh3Xw==",
-      "dev": true,
-      "requires": {
-        "synchronous-promise": "^2.0.10"
-      }
-    },
     "jest-pnp-resolver": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
@@ -9879,12 +9870,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true
-    },
-    "synchronous-promise": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.13.tgz",
-      "integrity": "sha512-R9N6uDkVsghHePKh1TEqbnLddO2IY25OcsksyFp/qBe7XYd0PVbKEWxhcdMhpLzE1I6skj5l4aEZ3CRxcbArlA==",
       "dev": true
     },
     "table": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "husky": "^4.2.5",
     "io-ts": "^2.2.4",
     "jest": "^26.0.1",
-    "jest-mock-axios": "^4.2.0",
     "lint-staged": "^10.2.9",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "husky": "^4.2.5",
     "io-ts": "^2.2.4",
     "jest": "^26.0.1",
+    "jest-mock-axios": "^4.2.0",
     "lint-staged": "^10.2.9",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",
@@ -90,10 +91,9 @@
     "typescript": "^3.9.5"
   },
   "dependencies": {
-    "jest-mock-axios": "^4.2.0"
+    "axios": "^0.19.2"
   },
   "peerDependencies": {
-    "axios": ">=0.17.0 <0.20.0",
     "fp-ts": "^2",
     "io-ts": "^2.2.4"
   }

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -22,6 +22,7 @@ export default {
     'axios',
     'fp-ts/lib/Either',
     'fp-ts/lib/Task',
+    'fp-ts/lib/TaskEither',
     'fp-ts/lib/pipeable',
     'io-ts/lib/Decoder',
     'io-ts/lib/Schema',

--- a/src/lib/check-endpoint.ts
+++ b/src/lib/check-endpoint.ts
@@ -1,4 +1,3 @@
-import * as T from 'fp-ts/lib/Task'
 import * as E from 'fp-ts/lib/Either'
 import * as TE from 'fp-ts/lib/TaskEither'
 import { AxiosResponse } from 'axios'
@@ -31,10 +30,10 @@ export type CheckEndpointDeps<T> = {
 export const checkEndpoint = <R>(deps: CheckEndpointDeps<R>): TE.TaskEither<Failure, Success<R>> => {
   return pipe(
     getTask<TypeOf<typeof deps.expectations.schema>>(deps.url),
-    T.map(r => pipe(
+    TE.chain(r => TE.fromEither(pipe(
       r,
       assertEndpointStatus(deps.expectations.status),
       E.chain(assertEndpointSchema(deps.expectations.schema))
-    )),
+    ))),
   )
 }

--- a/src/lib/request.spec.ts
+++ b/src/lib/request.spec.ts
@@ -1,0 +1,34 @@
+import * as fc from 'fast-check'
+import * as E from 'fp-ts/lib/Either'
+import * as T from 'fp-ts/lib/Task'
+import axios from 'axios'
+import {getTask} from './request'
+
+jest.mock('axios', () => ({
+  get: jest.fn()
+}))
+
+describe('request functions', () => {
+  describe('getTask', () => {
+    it('safely handles exceptions and provides their message', () => {
+      fc.assert(fc.property(
+        fc.fullUnicodeString(),
+        fc.webUrl(),
+        (msg, url) => {
+          (axios.get as jest.Mock).mockImplementationOnce((_: string) => {
+            throw Error(msg)
+          })
+
+          const res = getTask(url)
+          const runAssertions = T.task.map(res, e => {
+            expect(E.isLeft(e)).toBe(true)
+            E.either.mapLeft(e, m => {
+              expect(m.message).toBe(msg)
+            })
+          })
+          runAssertions()
+        }
+      ), { numRuns: 20 })
+    })
+  })
+})

--- a/src/lib/request.spec.ts
+++ b/src/lib/request.spec.ts
@@ -30,5 +30,21 @@ describe('request functions', () => {
         }
       ), { numRuns: 20 })
     })
+
+    it('provides a default message if none was given', () => {
+      (axios.get as jest.Mock).mockImplementationOnce((_: string) => {
+        throw 'Error'
+      })
+
+      const url = 'www.internet.web'
+      const res = getTask(url)
+      const runAssertions = T.task.map(res, e => {
+        expect(E.isLeft(e)).toBe(true)
+        E.either.mapLeft(e, m => {
+          expect(m.message).toContain(url)
+        })
+      })
+      runAssertions()
+    })
   })
 })

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -1,9 +1,20 @@
-import * as T from 'fp-ts/lib/Task'
+import * as TE from 'fp-ts/lib/TaskEither'
 import axios, { AxiosResponse } from 'axios'
+import {Failure} from './check-endpoint'
+
+type HasMessage = { message: unknown }
+type HasStringMessage = { message: string }
 
 /** Return a Task wrapping an axios GET request */
 export const getTask =
-  <A>(url: string): T.Task<AxiosResponse<A>> =>
-    async (): Promise<AxiosResponse<A>> => {
-      return axios.get<A>(url)
-    }
+  <A>(url: string): TE.TaskEither<Failure, AxiosResponse<A>> =>
+    TE.tryCatch(
+      async () => axios.get<A>(url),
+      e =>
+        typeof e === 'object'
+        && e !== null
+        && 'message' in e
+        && typeof (e as HasMessage).message === 'string'
+          ? { message: (e as HasStringMessage).message }
+          : { message: `Could not GET ${url}`}
+    )

--- a/test/check-endpoint.spec.ts
+++ b/test/check-endpoint.spec.ts
@@ -1,24 +1,43 @@
 import * as E from 'fp-ts/lib/Either'
 import * as RTE from 'fp-ts/lib/ReaderTaskEither'
-import { make } from 'io-ts/lib/Schema'
-import { checkEndpoint } from '../dist'
+import {make, TypeOf} from 'io-ts/lib/Schema'
+import { checkEndpoint } from '../dist/index'
+import {CheckEndpointDeps, Failure} from '../src'
 
 describe('The checkEndpoint function', () => {
   it('fetches and validates data from an api', async () => {
-    const schema = make(s => s.type({
+    const postSchema = make(s => s.type({
       id: s.number
     }))
 
     const deps = {
       url: 'https://jsonplaceholder.typicode.com/posts/1',
       expectations: {
-        schema,
+        schema: postSchema,
         status: 200
       }
     }
 
-    RTE.run(checkEndpoint, deps).then(r => {
+    await RTE.run(checkEndpoint, deps).then(r => {
       expect(E.isRight(r)).toBe(true)
+    })
+  })
+
+  it('does not throw an exception for 404', async () => {
+    const noneSchema = make(s => s.string)
+    type None = TypeOf<typeof noneSchema>
+
+    const deps: CheckEndpointDeps<None> = {
+      url: 'https://jsonplaceholder.typicode.com/grumpus/1',
+      expectations: {
+        schema: noneSchema,
+        status: 200
+      }
+    }
+
+    await RTE.run(checkEndpoint, deps).then(r => {
+      expect(E.isLeft(r)).toBe(true)
+      expect((r as E.Left<Failure>).left.message).toContain('404')
     })
   })
 })


### PR DESCRIPTION
fp-ts offers a `tryCatch` combinator which wraps thrown exceptions into the Either structure. This should be used to prevent these exceptions from stopping a test.

fixes #7 